### PR TITLE
Added package-source flag to replace where package comes from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sbom_to_snyk_depgraph/ignore.txt
 sbom_to_snyk_depgraph/__pycache__/
 .vscode/settings.json
 .python-version
+sbom_to_snyk_depgraph/.dccache

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+sbom_to_snyk_depgraph/ignore.txt
+.github
+.DS_Store
+sbom_to_snyk_depgraph/__pycache__/
+.vscode/settings.json
+.python-version

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 # sbom-to-snyk-depgraph
 Convert [CycloneDX](https://cyclonedx.org/) SBOM to snyk depgraph and monitor/test/print
 
+# Note - this script requires FF:depGraphApi to be enabled at group level or a 404 will be returned
+
 ```
 Usage: main.py [OPTIONS] COMMAND [ARGS]...
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Options:
                                   required]
   ----ignore-file TEXT            Full path to a file containing new line delimited
                                   dependencies to ignore
+  --package-source TEXT           Type of package manager (npm, maven, etc), overrides auto-detect
   --prune-repeated-subdependencies / --no-prune-repeated-subdependencies
                                   Use if too many repeated sub dependencies
                                   causes test or monitor to fail  [default:

--- a/sbom_to_snyk_depgraph/main.py
+++ b/sbom_to_snyk_depgraph/main.py
@@ -76,12 +76,13 @@ def main(
         if package_source is None:
             package_source = get_package_manager_from_sbom()
 
+        if package_source is None:
+            typer.echo("No package source defined or detected (tried purl and name for pkg:<package manager>)", file=sys.stderr)
+            sys.exit(1)
+            
         logger.debug("package_source: " + package_source)
         dep_graph = DepGraph(package_source, False)
 
-        if package_source is None:
-            print("No package source defined or detected (tried purl and name for pkg:<package manager>)")
-            exit
 
         root_component_ref = "unknown"
 

--- a/sbom_to_snyk_depgraph/snyk_depgraph.py
+++ b/sbom_to_snyk_depgraph/snyk_depgraph.py
@@ -180,10 +180,17 @@ class DepGraph(object):
     def set_root_node_package(self, root_node: str):
         logger.debug(f"{root_node=}")
         root_pkg = self.dep_graph['depGraph']['pkgs'][0]
+
+        if root_node.count("@") > 0 :
+            root_node_split = root_node.split("@")
+            root_pkg['info']['name'] = f"{root_node_split[0]}"
+            root_pkg['info']['version'] = f"{root_node_split[1]}"
+        else :
+            root_pkg['info']['name'] = f"{root_node}"
+            root_pkg['info']['version'] = f"0.0.0"
+            root_node = f"{root_node}0.0.0"
+
         root_pkg['id'] = f"{root_node}"
-        root_node_split = root_node.split("@")
-        root_pkg['info']['name'] = f"{root_node_split[0]}"
-        root_pkg['info']['version'] = f"{root_node_split[1]}"
 
         graph = self.dep_graph['depGraph']['graph']
         graph['rootNodeId'] = root_node


### PR DESCRIPTION
- Added package-source flag
- moved project-name flag to top level so print-graph returns 
- stripped out pkg:maven and replaced with regex

webnext test script returns empty dependency tree - need to confirm if that's a bug or not